### PR TITLE
Fixes the "permanent redirect" errors on img download

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,0 +1,14 @@
+# installer script for some PyPI packages we need...
+
+import launch
+pkgs = [
+        {"fake_useragent": "fake-useragent"},
+        {"PIL": "PIL"},
+        {"requests": "requests"}
+       ]
+
+for pkg in pkgs:
+    key, val = next(iter(pkg.items()))
+    if not launch.is_installed(key):
+        print(f'installing "{val}"')
+        launch.run_pip(f'install {val}', "requirements for CivitAI Browser")

--- a/install.py
+++ b/install.py
@@ -10,5 +10,4 @@ pkgs = [
 for pkg in pkgs:
     key, val = next(iter(pkg.items()))
     if not launch.is_installed(key):
-        print(f'installing "{val}"')
         launch.run_pip(f'install {val}', "requirements for CivitAI Browser")


### PR DESCRIPTION
Also uses a random UA for each request, adds an installer script for the [fake-useragent](https://github.com/fake-useragent/fake-useragent), [PIL](https://github.com/python-pillow/Pillow), and [requests](https://github.com/psf/requests) modules, throws an exception when a user tries to download images before selecting a model filename.